### PR TITLE
Improve WiFi scanning to show all networks and refactor setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Installation complete. wifi-unredactor is now available in /Users/noperator/Appl
 You'll need to **grant location services permission** to this application for it to work properly.
 
 1. `𝄢 open ~/Applications/wifi-unredactor.app` to trigger the initial prompt for location services permission. Click allow.
-2. Navigate to System Settings > Privacy & Security > Location Services. If you don't see `wifi-unredactor` in the list of apps, try refreshing the list by clicking the back button and then clicking back into Location Services. Toggle `wifi-unredactor` on. (For some reason, clicking allow in step 1 makes this app show up on the list, but in the off position.)
+2. Scroll to and enable `wifi-unredactor` [here](x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices).
+
+> If this link doesn't work, you can try `open "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices"` in Terminal, or manually navigate to System Settings > Privacy & Security > Location Services. If you don't see `wifi-unredactor` in the list of apps, try refreshing the list by clicking the back button and then clicking back into Location Services. Toggle `wifi-unredactor` on. (For some reason, clicking allow in step 1 makes this app show up on the list, but in the off position.)
 
 ### Usage
 

--- a/wifi-unredactor.app/Contents/MacOS/wifi-unredactor.swift
+++ b/wifi-unredactor.app/Contents/MacOS/wifi-unredactor.swift
@@ -14,41 +14,56 @@ class AppDelegate: NSObject, NSApplicationDelegate, CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         if status == .authorizedAlways || status == .authorized {
-            if let interface = CWWiFiClient.shared().interface() {
-                var jsonOutput: [String: String] = [:]
+            guard let interface = CWWiFiClient.shared().interface() else {
+                print(toJSON(["error": "no wifi interface found"]))
+                NSApp.terminate(nil)
+                return
+            }
 
-                jsonOutput["interface"] = interface.interfaceName
+            do {
+                let networks = try interface.scanForNetworks(withName: nil)
 
-                if let ssid = interface.ssid() {
-                    jsonOutput["ssid"] = ssid
-                } else {
-                    jsonOutput["ssid"] = "failed to retrieve SSID"
-                }
+                let accessPoints: [[String: Any]] = networks
+                    .sorted { $0.rssiValue > $1.rssiValue } // strongest signal first
+                    .map { network in
+                        [
+                            "ssid":    network.ssid   ?? "<hidden>",
+                            "bssid":   network.bssid  ?? "unknown",
+                            "rssi":    network.rssiValue,
+                            "channel": network.wlanChannel?.channelNumber ?? -1,
+                        ]
+                    }
 
-                if let bssid = interface.bssid() {
-                    jsonOutput["bssid"] = bssid
-                } else {
-                    jsonOutput["bssid"] = "failed to retrieve BSSID"
-                }
+                let output: [String: Any] = [
+                    "interface":    interface.interfaceName ?? "unknown",
+                    "access_points": accessPoints
+                ]
 
-                if let jsonData = try? JSONSerialization.data(withJSONObject: jsonOutput, options: .prettyPrinted),
+                if let jsonData = try? JSONSerialization.data(withJSONObject: output, options: .prettyPrinted),
                    let jsonString = String(data: jsonData, encoding: .utf8) {
                     print(jsonString)
                 } else {
-                    print("error: failed to create JSON")
+                    print(toJSON(["error": "failed to serialize JSON"]))
                 }
+
+            } catch {
+                print(toJSON(["error": "scan failed: \(error.localizedDescription)"]))
             }
+
             NSApp.terminate(nil)
+
         } else {
-            let jsonOutput = ["error": "location services denied"]
-            if let jsonData = try? JSONSerialization.data(withJSONObject: jsonOutput, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8) {
-                print(jsonString)
-            } else {
-                print("error: failed to create JSON")
-            }
+            print(toJSON(["error": "location services denied"]))
             NSApp.terminate(nil)
         }
+    }
+
+    func toJSON(_ dict: [String: String]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted),
+              let str = String(data: data, encoding: .utf8) else {
+            return #"{"error": "json serialization failed"}"#
+        }
+        return str
     }
 }
 


### PR DESCRIPTION
Scan for all nearby networks instead of just the current connection, sorted by signal strength.

## Changes
- Scan for all nearby networks instead of just current connection
- Sort networks by signal strength (RSSI) 
- Return network list with SSID, BSSID, RSSI, and channel info
- Improve error handling with guard statements and helper function
- Simplify location services setup instructions with direct system preferences link

Fixes #6

Thanks @sgielen for the guidance on improving this implementation.